### PR TITLE
Add jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,7 @@ android {
 }
 
 repositories {
+    jcenter()
     mavenCentral()
     maven {
         url "https://maven.google.com"


### PR DESCRIPTION
## Issue
* What went wrong:
A problem occurred configuring project ':@connected-home_react-native-fast-image'.
> Could not resolve all artifacts for configuration ':@connected-home_react-native-fast-image:classpath'.
   > Could not download lint.jar (com.android.tools.lint:lint:25.3.3)
      > Could not get resource 'https://jcenter.bintray.com/com/android/tools/lint/lint/25.3.3/lint-25.3.3.jar'.
         > Could not HEAD 'https://jcenter.bintray.com/com/android/tools/lint/lint/25.3.3/lint-25.3.3.jar'.
            > Connect to jcenter.bintray.com:443 [jcenter.bintray.com/35.156.75.35, jcenter.bintray.com/18.195.111.75] failed: Connection refused (Connection refused)

## Solution
Add `jcenter` as a fallback