### PR TITLE
HCM-919: fix crash on Android

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -96,7 +96,9 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         eventEmitter.receiveEvent(viewId, REACT_ON_LOAD_START_EVENT, new WritableNativeMap());
 
         // Image resize
-        view.imageSizeOverride = source.getMap("resize"); 
+        if (source.hasKey("resize")) {
+            view.imageSizeOverride = source.getMap("resize");
+        }
 
         if (requestManager != null) {
             requestManager


### PR DESCRIPTION
### Description of the issue
App crashed on home screen on Android.

### Solution to the issue
Add additional check for `resize` property, which was introduced in https://github.com/ConnectedHomes/react-native-fast-image/commit/f36ce672bea8e96835ea2aa194980e6f9738218a

### Before/After screenshots 📷

| Before               | After               |
| -------------------- | ------------------- |
| <img width="352" alt="Screenshot 2019-03-25 at 19 16 37" src="https://user-images.githubusercontent.com/1313744/55012344-551da280-4ff8-11e9-8efe-75d597796f61.png"> | <img width="428" alt="Screenshot 2019-03-26 at 18 53 18" src="https://user-images.githubusercontent.com/1313744/55012423-77172500-4ff8-11e9-8ded-def9e8d060fb.png"> |

### Link to Jira ticket

[HCM-919](https://jira.bgchtest.info/browse/HCM-919)